### PR TITLE
Remove feeds and scraper confirmed dead in production; improve image coverage

### DIFF
--- a/.github/workflows/daily-scraper.yml
+++ b/.github/workflows/daily-scraper.yml
@@ -71,8 +71,12 @@ jobs:
     - name: Test MongoDB connection
       env:
         MONGODB_URI: ${{ secrets.MONGODB_URI }}
-        MONGODB_DATABASE: ${{ secrets.MONGODB_DATABASE }}
-        MONGODB_COLLECTION: ${{ secrets.MONGODB_COLLECTION }}
+        # Database/collection names are not sensitive - define them as
+        # repository *variables* (Settings -> Secrets and variables ->
+        # Actions -> Variables) so logs stop masking the word they contain;
+        # secrets remain as a fallback until the variables are set.
+        MONGODB_DATABASE: ${{ vars.MONGODB_DATABASE || secrets.MONGODB_DATABASE }}
+        MONGODB_COLLECTION: ${{ vars.MONGODB_COLLECTION || secrets.MONGODB_COLLECTION }}
       run: |
         echo "🔍 Testing MongoDB connection..."
         python -c "
@@ -114,8 +118,12 @@ jobs:
     - name: Run article scraper
       env:
         MONGODB_URI: ${{ secrets.MONGODB_URI }}
-        MONGODB_DATABASE: ${{ secrets.MONGODB_DATABASE }}
-        MONGODB_COLLECTION: ${{ secrets.MONGODB_COLLECTION }}
+        # Database/collection names are not sensitive - define them as
+        # repository *variables* (Settings -> Secrets and variables ->
+        # Actions -> Variables) so logs stop masking the word they contain;
+        # secrets remain as a fallback until the variables are set.
+        MONGODB_DATABASE: ${{ vars.MONGODB_DATABASE || secrets.MONGODB_DATABASE }}
+        MONGODB_COLLECTION: ${{ vars.MONGODB_COLLECTION || secrets.MONGODB_COLLECTION }}
         TARGET_ARTICLE_COUNT: ${{ inputs.target_count || '50' }}
         LOG_LEVEL: ${{ inputs.log_level || 'INFO' }}
         AUTO_CLEANUP_ENABLED: true

--- a/config/settings.py
+++ b/config/settings.py
@@ -94,9 +94,6 @@ class Config:
         "wired": "https://www.wired.com/feed/rss",
         "the_verge": "https://www.theverge.com/rss/index.xml",
         "ars_technica": "https://arstechnica.com/feed/",
-        # NOTE: engadget blocks non-browser clients (HTTP 403) from
-        # datacenter IPs; kept in case it works from other networks
-        "engadget": "https://www.engadget.com/rss.xml",
         "cnet": "https://www.cnet.com/rss/news/",
         "the_register": "https://www.theregister.com/headlines.rss",
         "zdnet": "https://www.zdnet.com/news/rss.xml",
@@ -116,9 +113,6 @@ class Config:
         # Science & Health - Research and Medical News
         "nature_news": "https://www.nature.com/nature.rss",
         "scientific_american": "http://rss.sciam.com/ScientificAmerican-Global",
-        # NOTE: newscientist.com rejects non-browser clients (HTTP 406);
-        # kept in case it works from other networks
-        "new_scientist": "https://www.newscientist.com/feed/home/",
         "science_daily": "https://www.sciencedaily.com/rss/all.xml",
         "phys_org": "https://phys.org/rss-feed/",
         "live_science": "https://www.livescience.com/feeds/all",
@@ -146,9 +140,6 @@ class Config:
         "hackernews": "https://hnrss.org/frontpage",
         # Specialized Quality Publications
         "mit_tech_review": "https://www.technologyreview.com/feed/",
-        # NOTE: theatlantic.com serves this feed to browsers but returns 403
-        # to non-browser clients; kept in case it works from other networks
-        "atlantic": "https://www.theatlantic.com/feed/all/",
         # Eastern Europe, Russia & Belarus - Independent & Regional Sources
         "moscow_times": "https://www.themoscowtimes.com/rss/news",
         "meduza_en": "https://meduza.io/rss/en/all",

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -6,7 +6,6 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from bs4 import BeautifulSoup
 import json
-import re
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 import time
@@ -217,14 +216,51 @@ class ArticleScraper:
 
             # Quick check for common news domains that are likely to have meta tags
             trusted_domains = [
+                # Global / UK
                 "bbc.com",
                 "cnn.com",
-                "reuters.com",
+                "theguardian.com",
+                "aljazeera.com",
+                "independent.co.uk",
+                "news.sky.com",
+                "euronews.com",
+                "time.com",
+                # US national
+                "nytimes.com",
+                "washingtonpost.com",
+                "nbcnews.com",
+                "cbsnews.com",
+                "abcnews.go.com",
+                "foxnews.com",
+                "politico.com",
+                "axios.com",
+                "thehill.com",
+                "latimes.com",
+                # Tech & business
                 "bloomberg.com",
                 "techcrunch.com",
                 "theverge.com",
                 "wired.com",
                 "forbes.com",
+                "arstechnica.com",
+                "cnet.com",
+                "zdnet.com",
+                "venturebeat.com",
+                "theregister.com",
+                "spectrum.ieee.org",
+                "cnbc.com",
+                "marketwatch.com",
+                "fortune.com",
+                # Russia & Eastern Europe
+                "meduza.io",
+                "novayagazeta.eu",
+                "thebell.io",
+                "kommersant.ru",
+                "rbc.ru",
+                "vedomosti.ru",
+                "interfax.ru",
+                "themoscowtimes.com",
+                "kyivindependent.com",
             ]
 
             if not any(domain in page_url.lower() for domain in trusted_domains):
@@ -263,71 +299,6 @@ class ArticleScraper:
 
         except Exception as e:
             logger.debug(f"Error extracting image from webpage {page_url}: {e}")
-            return ""
-
-    def _extract_medium_image(self, link_element) -> str:
-        """Extract image URL from Medium article link context with enhanced methods."""
-        try:
-            # Look for nearby img elements in the same container
-            parent = link_element.parent
-            if parent:
-                # Look for img tags in the parent container and siblings
-                for container in [parent, parent.parent] if parent.parent else [parent]:
-                    if not container:
-                        continue
-
-                    # Look for img tags in the container
-                    img = container.find("img")
-                    if img:
-                        # Check src attribute
-                        if img.get("src"):
-                            src = img["src"]
-                            if self._is_valid_image_url(src):
-                                return self._normalize_image_url(src)
-
-                        # Check data-src for lazy loading
-                        if img.get("data-src"):
-                            src = img["data-src"]
-                            if self._is_valid_image_url(src):
-                                return self._normalize_image_url(src)
-
-                        # Check srcset
-                        if img.get("srcset"):
-                            srcset = img["srcset"]
-                            urls = srcset.split(",")
-                            if urls:
-                                first_url = urls[0].strip().split(" ")[0]
-                                if self._is_valid_image_url(first_url):
-                                    return self._normalize_image_url(first_url)
-
-                # Look for background images in style attributes
-                for element in container.find_all(
-                    ["div", "span", "section", "article"], style=True
-                ):
-                    style = element.get("style", "")
-                    if "background-image" in style:
-                        # Extract URL from background-image: url(...)
-                        match = re.search(r'url\(["\']?(.*?)["\']?\)', style)
-                        if match:
-                            img_url = match.group(1)
-                            if self._is_valid_image_url(img_url):
-                                return self._normalize_image_url(img_url)
-
-                # Look for picture elements (responsive images)
-                picture = container.find("picture")
-                if picture:
-                    source = picture.find("source")
-                    if source and source.get("srcset"):
-                        srcset = source["srcset"]
-                        urls = srcset.split(",")
-                        if urls:
-                            first_url = urls[0].strip().split(" ")[0]
-                            if self._is_valid_image_url(first_url):
-                                return self._normalize_image_url(first_url)
-
-            return ""
-        except Exception as e:
-            logger.debug(f"Error extracting Medium image: {e}")
             return ""
 
     def get_rss_articles(
@@ -381,70 +352,6 @@ class ArticleScraper:
             logger.error(f"Error fetching RSS feed {feed_url}: {str(e)}")
             return []
 
-    def scrape_medium_trending(self, max_articles: int = 5) -> List[Dict[str, Any]]:
-        """Scrape Medium trending articles."""
-        try:
-            url = "https://medium.com/tag/trending"
-            response = self.session.get(url, timeout=10)
-            response.raise_for_status()
-
-            soup = BeautifulSoup(response.content, "html.parser")
-
-            articles = []
-            seen_urls = set()  # Track URLs to avoid duplicates
-            # Medium uses dynamic loading, so we'll try to find article links
-            article_links = soup.find_all("a", href=True)
-
-            for link in article_links:
-                href = link.get("href", "")
-                # Only include actual article URLs with /p/ pattern
-                # Exclude user profiles (/@username without /p/)
-                if "/p/" in href:
-                    # Normalize the URL
-                    if href.startswith("/"):
-                        href = "https://medium.com" + href
-                    elif href.startswith("https://medium.com"):
-                        pass
-                    else:
-                        continue
-
-                    # Remove query parameters and fragments for deduplication
-                    base_url = href.split("?")[0].split("#")[0]
-
-                    # Skip if we've already seen this URL
-                    if base_url in seen_urls:
-                        continue
-
-                    seen_urls.add(base_url)
-
-                    title = link.get_text(strip=True)
-                    # More strict title validation - should be meaningful article title
-                    if title and len(title) > 20 and len(title) < 200:
-                        # Try to extract image from the link's context
-                        image_url = self._extract_medium_image(link)
-
-                        articles.append(
-                            {
-                                "title": title,
-                                "url": base_url,
-                                "published": datetime.now(timezone.utc).isoformat(),
-                                "summary": "",
-                                "source": "medium.com",
-                                "tags": ["trending"],
-                                "image": image_url,
-                            }
-                        )
-
-                        if len(articles) >= max_articles:
-                            break
-
-            logger.info(f"Scraped {len(articles)} trending articles from Medium")
-            return articles
-
-        except Exception as e:
-            logger.error(f"Error scraping Medium trending: {str(e)}")
-            return []
-
     def _fetch_rss_feed_safe(self, feed_info: tuple) -> List[Dict[str, Any]]:
         """Thread-safe wrapper for RSS feed fetching."""
         feed_name, feed_url, max_articles = feed_info
@@ -456,18 +363,6 @@ class ArticleScraper:
 
         except Exception as e:
             logger.error(f"❌ Error processing feed {feed_name}: {e}")
-            return []
-
-    def _fetch_medium_trending_safe(self, max_articles: int) -> List[Dict[str, Any]]:
-        """Thread-safe wrapper for Medium trending scraping."""
-        try:
-            logger.info("🔄 Fetching Medium trending in thread...")
-            articles = self.scrape_medium_trending(max_articles)
-            logger.info(f"✅ Medium trending: Found {len(articles)} articles")
-            return articles
-
-        except Exception as e:
-            logger.error(f"❌ Error scraping Medium trending: {e}")
             return []
 
     def scrape_inshorts_articles(
@@ -815,9 +710,6 @@ class ArticleScraper:
             feed_name = f"medium_pub_{i+1}"
             tasks.append(("rss", feed_name, pub_feed, 2))
 
-        # Add Medium trending as a special task
-        tasks.append(("trending", "medium_trending", None, 5))
-
         # Add InShorts API as the highest priority task with more categories
         inshorts_categories = ["all_news", "top_stories"]
         tasks.append(("inshorts", "inshorts_api", inshorts_categories, None))
@@ -838,10 +730,6 @@ class ArticleScraper:
                 if task_type == "rss":
                     future = executor.submit(
                         self._fetch_rss_feed_safe, (name, url_or_data, max_articles)
-                    )
-                elif task_type == "trending":
-                    future = executor.submit(
-                        self._fetch_medium_trending_safe, max_articles
                     )
                 elif task_type == "inshorts":
                     future = executor.submit(self._fetch_inshorts_safe, url_or_data)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -188,12 +188,10 @@ class TestArticleScraper:
 
     @patch("src.scraper.time.sleep")
     @patch.object(ArticleScraper, "get_rss_articles")
-    @patch.object(ArticleScraper, "scrape_medium_trending")
     @patch.object(ArticleScraper, "scrape_inshorts_articles")
     def test_scrape_daily_articles(
         self,
         mock_inshorts,
-        mock_trending,
         mock_rss,
         mock_sleep,
         scraper,
@@ -201,7 +199,6 @@ class TestArticleScraper:
     ):
         """Test daily article scraping."""
         mock_rss.return_value = [sample_articles[0]]
-        mock_trending.return_value = [sample_articles[1]]
         mock_inshorts.return_value = [
             {
                 "title": "InShorts Test Article",
@@ -349,58 +346,4 @@ class TestArticleScraper:
         topics = scraper.get_inshorts_trending_topics()
 
         assert topics == []
-        mock_get.assert_called_once()
-
-    @patch("src.scraper.requests.Session.get")
-    def test_scrape_medium_trending(self, mock_get, scraper):
-        """Test Medium trending article scraping."""
-        # Mock Medium page response
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.content = b"""
-        <html>
-            <body>
-                <a href="/p/article-one-12345">This is a great article title here</a>
-                <a href="/@username">Just a profile</a>
-                <a href="/p/article-two-67890">Another excellent article title</a>
-            </body>
-        </html>
-        """
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        articles = scraper.scrape_medium_trending(max_articles=5)
-
-        # Should only get actual articles (with /p/), not profiles
-        assert len(articles) == 2
-        for article in articles:
-            assert "/p/" in article["url"]
-            assert "/@" not in article["url"] or "/p/" in article["url"]
-            assert len(article["title"]) > 20  # Should have meaningful titles
-        mock_get.assert_called_once()
-
-    @patch("src.scraper.requests.Session.get")
-    def test_scrape_medium_trending_deduplication(self, mock_get, scraper):
-        """Test that Medium scraping removes duplicate URLs."""
-        # Mock Medium page with duplicate article links
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.content = b"""
-        <html>
-            <body>
-                <a href="/p/article-one-12345?source=homepage">This is a great article title here</a>
-                <a href="/p/article-one-12345">This is a great article title here</a>
-                <a href="/p/article-two-67890">Another excellent article title</a>
-            </body>
-        </html>
-        """
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        articles = scraper.scrape_medium_trending(max_articles=5)
-
-        # Should deduplicate articles with same base URL
-        assert len(articles) == 2
-        urls = [article["url"] for article in articles]
-        assert len(urls) == len(set(urls))  # All URLs should be unique
         mock_get.assert_called_once()


### PR DESCRIPTION
## Summary

Follow-up to #14, based on inspecting production run [31151705898](https://github.com/athrvk/daily-article-scrapper/actions/runs/31151705898) (the first run after the merge — 94/97 feeds returned articles, cleanup deleted 22,650 stale documents, 50/50 database writes succeeded).

### Remove sources confirmed dead from GitHub Actions

- **The Atlantic (403), Engadget (403), New Scientist (406)** — the production logs show the same blocks seen from other datacenter networks, so these feeds never contribute articles. Removed from `RSS_FEEDS`.
- **Medium trending scraper** — `medium.com/tag/trending` is JS-rendered *and* returns 403 to GitHub Actions (confirmed in the same run), so `scrape_medium_trending` has never produced articles in production. Removed along with its helpers (`_fetch_medium_trending_safe`, `_extract_medium_image`) and tests. Medium content still flows in through the 10 publication RSS feeds.

### Improve image coverage

The run showed image coverage dropped to 36% after InShorts (the most image-rich source) was down-weighted. The og:image/Twitter-card fallback only fetched pages from a hardcoded list of 8 domains; that list now covers ~40 domains spanning the US, Russia, tech, and business sources. Verified live: e.g. Moscow Times articles without feed images now resolve an og:image.

### Readable workflow logs

Actions masks the word "articles" in every log line because `MONGODB_COLLECTION` is stored as a secret with that value. Database/collection names aren't sensitive (only the URI is), so the workflow now prefers repository **variables** for `MONGODB_DATABASE`/`MONGODB_COLLECTION` with the existing secrets as fallback. To get readable logs, add those two under Settings → Secrets and variables → Actions → **Variables**; nothing breaks if you don't.

## Test plan

- [x] `pytest tests/` — 23 passed
- [x] `flake8` / `black --check` — clean
- [x] Live-verified og:image extraction against newly trusted domains
- [x] Per-feed results cross-checked against production run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GypiCjP9DNatF1PxY7U2CP

---
_Generated by [Claude Code](https://claude.ai/code/session_01GypiCjP9DNatF1PxY7U2CP)_