### PR TITLE
Add author field extraction to RSS and InShorts articles

### DIFF
--- a/src/scraper.py
+++ b/src/scraper.py
@@ -334,6 +334,14 @@ class ArticleScraper:
                         *parsed_date[:6], tzinfo=timezone.utc
                     ).isoformat()
 
+                # feedparser normalizes both Atom <author><name> and RSS
+                # dc:creator into author_detail.name when the feed provides
+                # structured author data; entry.author is the raw string
+                # form (sometimes just a name, sometimes "email (Name)").
+                # Prefer the structured name, fall back to the raw string.
+                author_detail = entry.get("author_detail", {}) or {}
+                author = author_detail.get("name", "") or entry.get("author", "")
+
                 article = {
                     "title": entry.get("title", "No Title"),
                     "url": entry.get("link", ""),
@@ -342,6 +350,7 @@ class ArticleScraper:
                     "source": urlparse(feed_url).netloc,
                     "tags": [tag.term for tag in entry.get("tags", [])],
                     "image": image_url,
+                    "author": author,
                 }
                 articles.append(article)
 
@@ -468,7 +477,11 @@ class ArticleScraper:
                 "tags": [category],
                 "image": news.get("image_url", ""),
                 "inshorts_id": news.get("hash_id", ""),
+                # original_source kept for backward compatibility; author
+                # mirrors it so callers can read one field regardless of
+                # whether the article came from RSS or InShorts.
                 "original_source": news.get("author_name", ""),
+                "author": news.get("author_name", ""),
             }
 
             # Validate required fields

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -151,6 +151,76 @@ class TestArticleScraper:
         assert articles[0]["title"] == "Test Article"
         assert articles[0]["url"] == "https://example.com/test"
         assert "image" in articles[0]  # Ensure image field is present
+        assert articles[0]["author"] == ""  # No author data in this mock
+
+    @patch("src.scraper.requests.Session.get")
+    @patch("src.scraper.feedparser.parse")
+    def test_get_rss_articles_author_from_author_detail(
+        self, mock_parse, mock_get, scraper
+    ):
+        """Structured author_detail.name (Atom <author>, dc:creator) wins."""
+        mock_get.return_value = Mock(content=b"<rss/>")
+        mock_entry = Mock()
+        mock_entry.tags = []
+        mock_entry.media_content = []
+        mock_entry.media_thumbnail = []
+        mock_entry.enclosures = []
+        mock_entry.links = []
+        mock_entry.content = []
+        mock_entry.description = ""
+        for attr in ["image", "featured_image", "thumbnail", "img", "picture"]:
+            setattr(mock_entry, attr, "")
+        mock_entry.get.side_effect = lambda key, default="": {
+            "title": "Byline Article",
+            "link": "https://example.com/byline",
+            "published": "2025-01-01",
+            "summary": "Test summary",
+            "author_detail": {"name": "Jane Doe"},
+            "author": "jane@example.com (Jane Doe)",
+        }.get(key, default)
+
+        mock_feed = Mock()
+        mock_feed.entries = [mock_entry]
+        mock_feed.bozo = False
+        mock_parse.return_value = mock_feed
+
+        articles = scraper.get_rss_articles("https://example.com/feed")
+
+        assert articles[0]["author"] == "Jane Doe"
+
+    @patch("src.scraper.requests.Session.get")
+    @patch("src.scraper.feedparser.parse")
+    def test_get_rss_articles_author_falls_back_to_raw_string(
+        self, mock_parse, mock_get, scraper
+    ):
+        """Falls back to the raw `author` string when no author_detail exists."""
+        mock_get.return_value = Mock(content=b"<rss/>")
+        mock_entry = Mock()
+        mock_entry.tags = []
+        mock_entry.media_content = []
+        mock_entry.media_thumbnail = []
+        mock_entry.enclosures = []
+        mock_entry.links = []
+        mock_entry.content = []
+        mock_entry.description = ""
+        for attr in ["image", "featured_image", "thumbnail", "img", "picture"]:
+            setattr(mock_entry, attr, "")
+        mock_entry.get.side_effect = lambda key, default="": {
+            "title": "No Structured Author",
+            "link": "https://example.com/no-author-detail",
+            "published": "2025-01-01",
+            "summary": "Test summary",
+            "author": "John Smith",
+        }.get(key, default)
+
+        mock_feed = Mock()
+        mock_feed.entries = [mock_entry]
+        mock_feed.bozo = False
+        mock_parse.return_value = mock_feed
+
+        articles = scraper.get_rss_articles("https://example.com/feed")
+
+        assert articles[0]["author"] == "John Smith"
 
     def test_extract_image_from_html(self, scraper):
         """Test image extraction from HTML content."""
@@ -299,6 +369,7 @@ class TestArticleScraper:
         assert article["source"] == "inshorts.com"
         assert article["inshorts_id"] == "test-hash"
         assert article["original_source"] == "Test Source"
+        assert article["author"] == "Test Source"
         assert "top_stories" in article["tags"]
 
     def test_parse_inshorts_article_missing_fields(self, scraper):


### PR DESCRIPTION
## Summary
This PR adds author field extraction to both RSS feed articles and InShorts articles, ensuring consistent author data handling across different article sources.

## Key Changes
- **RSS articles**: Extract author information from feed entries with intelligent fallback logic
  - Prioritizes structured `author_detail.name` (from Atom `<author>` or RSS `dc:creator` tags)
  - Falls back to raw `author` string when structured data is unavailable
  - Defaults to empty string if no author information exists
  
- **InShorts articles**: Add `author` field that mirrors `original_source` for API consistency
  - Maintains backward compatibility by keeping `original_source` field
  - Allows callers to read author data uniformly regardless of article source

- **Tests**: Added comprehensive test coverage for author extraction scenarios
  - Test for structured author_detail extraction
  - Test for fallback to raw author string
  - Test for InShorts author field population

## Implementation Details
The RSS author extraction leverages feedparser's normalization behavior, which converts both Atom and RSS structured author formats into the `author_detail` dictionary. The implementation prefers this structured format but gracefully falls back to the raw `author` field for feeds that don't provide structured author data.

https://claude.ai/code/session_01J2QWzawzjQiUpsN7m3VENp