### PR TITLE
Reject generated social share-card images from image extraction

### DIFF
--- a/src/scraper.py
+++ b/src/scraper.py
@@ -24,6 +24,22 @@ class ArticleScraper:
     # Query parameters that only track referrals and break URL deduplication
     TRACKING_PARAMS = {"fbclid", "gclid", "igshid", "mc_cid", "mc_eid", "source"}
 
+    # Path/host fragments used by dynamically-generated social share cards
+    # (headline text rendered over a plain background), as opposed to real
+    # editorial photos. These get published as the RSS enclosure and as
+    # og:image/twitter:image alike (e.g. Meduza's meduza.io/imgly/share/...),
+    # so they must be rejected wherever image URLs are validated.
+    SHARE_CARD_URL_PATTERNS = (
+        "/imgly/share/",
+        "/api/og",
+        "og-image",
+        "ogimage",
+        "opengraph-image",
+        "social-image",
+        "share-image",
+        "sharingimage",
+    )
+
     def __init__(self, config: Config = None):
         """Initialize the scraper with configuration."""
         self.config = config or Config()
@@ -177,6 +193,11 @@ class ArticleScraper:
 
         # Skip obviously invalid URLs (but allow example.com for testing)
         if any(invalid in url.lower() for invalid in ["localhost", "127.0.0.1"]):
+            return False
+
+        # Skip generated social share cards (headline-as-text-image), which
+        # sources publish as their enclosure/og:image in place of a real photo
+        if any(pattern in url.lower() for pattern in self.SHARE_CARD_URL_PATTERNS):
             return False
 
         # Skip too short URLs

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -256,6 +256,36 @@ class TestArticleScraper:
         image_url = scraper._extract_image_from_rss_entry(empty_entry)
         assert image_url == ""
 
+    def test_is_valid_image_url_rejects_share_cards(self, scraper):
+        """Generated social share cards (headline-as-text-image) aren't real photos."""
+        share_card_urls = [
+            "https://meduza.io/imgly/share/1788217786/en/news/2026/09/01/some-article",
+            "https://example.com/api/og?title=Some+Headline",
+            "https://example.com/social-image/some-article.png",
+            "https://example.com/share-image/some-article.png",
+        ]
+        for url in share_card_urls:
+            assert scraper._is_valid_image_url(url) is False
+
+        assert scraper._is_valid_image_url("https://example.com/photos/real-photo.jpg") is True
+
+    def test_extract_image_from_rss_entry_skips_share_card_enclosure(self, scraper):
+        """A share-card enclosure should be rejected so real signals aren't shadowed."""
+        mock_enclosure = Mock()
+        mock_enclosure.type = "image/png"
+        mock_enclosure.href = "https://meduza.io/imgly/share/123/en/news/2026/09/01/article"
+
+        mock_entry = Mock()
+        mock_entry.media_content = []
+        mock_entry.media_thumbnail = []
+        mock_entry.enclosures = [mock_enclosure]
+        mock_entry.links = []
+        mock_entry.summary = "No real images here"
+        mock_entry.content = []
+
+        image_url = scraper._extract_image_from_rss_entry(mock_entry)
+        assert image_url == ""
+
     @patch("src.scraper.time.sleep")
     @patch.object(ArticleScraper, "get_rss_articles")
     @patch.object(ArticleScraper, "scrape_inshorts_articles")

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -267,13 +267,18 @@ class TestArticleScraper:
         for url in share_card_urls:
             assert scraper._is_valid_image_url(url) is False
 
-        assert scraper._is_valid_image_url("https://example.com/photos/real-photo.jpg") is True
+        assert (
+            scraper._is_valid_image_url("https://example.com/photos/real-photo.jpg")
+            is True
+        )
 
     def test_extract_image_from_rss_entry_skips_share_card_enclosure(self, scraper):
         """A share-card enclosure should be rejected so real signals aren't shadowed."""
         mock_enclosure = Mock()
         mock_enclosure.type = "image/png"
-        mock_enclosure.href = "https://meduza.io/imgly/share/123/en/news/2026/09/01/article"
+        mock_enclosure.href = (
+            "https://meduza.io/imgly/share/123/en/news/2026/09/01/article"
+        )
 
         mock_entry = Mock()
         mock_entry.media_content = []


### PR DESCRIPTION
## Summary

- Some sources (confirmed live: Meduza) publish a dynamically-generated "share card" — the headline rendered as text over a plain background — as **both** their RSS `<enclosure>` and their page's `og:image`/`twitter:image`, in place of a real editorial photo. Meduza's feed items have no real photo anywhere (`content:encoded` has zero `<img>` tags), so every extraction path converges on the same generated card, e.g. `meduza.io/imgly/share/...`.
- This surfaces downstream as an article "cover" that's just giant title text on black.
- Following the pattern used by established article extractors (newspaper3k/goose3 keep a URL-pattern blocklist as their validation choke point for ad/social/logo images), added `SHARE_CARD_URL_PATTERNS` and a rejection check in `_is_valid_image_url` — the single function every image-extraction path (RSS enclosure, media:content/thumbnail, og:image, twitter:image, embedded HTML `<img>`) already funnels through. Covers common generator path patterns beyond just Meduza (`/imgly/share/`, `/api/og`, `og-image`, `social-image`, `share-image`, etc.).
- When no real image survives, the article correctly falls back to `image: ""` (existing `_get_fallback_image` behavior), rather than a broken-looking share card.

## Verification

- Ran the scraper live against `https://meduza.io/rss/en/all`: articles with no real photo now get `""`; an article that does have a real editorial photo (`meduza.io/image/attachments/...`) is unaffected and still returned correctly.
- Added tests: `_is_valid_image_url` rejects known share-card URL shapes but still accepts a normal photo URL; `_extract_image_from_rss_entry` skips a share-card enclosure and falls through cleanly.

## Test plan

- [x] `python -m pytest tests/ -q` — all 27 tests pass (25 existing + 2 new)
- [x] Manual live check against `meduza.io/rss/en/all` confirms share cards are dropped and real photos are preserved

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2QWzawzjQiUpsN7m3VENp)_